### PR TITLE
Fix redirected page position for invalid input

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,20 +113,20 @@ app.use((err, req, res, next) => {
 // Setup server
 const port = process.env.PORT || 3000;
 /* HTTP */
-// app.listen(port, () => {
-//     console.log(`Listening on port: ${port}`);
-// });
+app.listen(port, () => {
+    console.log(`Listening on port: ${port}`);
+});
 
 /* HTTPS */
-const fs = require("fs");
-const https = require("https");
-https
-    .createServer(
-        {
-            key: fs.readFileSync("server.key"),
-            cert: fs.readFileSync("server.cert"),
-        }, app)
-    .listen(port, function () {
-        console.log(`Listening on port: ${port}`);
-    });
+// const fs = require("fs");
+// const https = require("https");
+// https
+//     .createServer(
+//         {
+//             key: fs.readFileSync("server.key"),
+//             cert: fs.readFileSync("server.cert"),
+//         }, app)
+//     .listen(port, function () {
+//         console.log(`Listening on port: ${port}`);
+//     });
 


### PR DESCRIPTION
Previously the page will reload and display the top of the page, rather than directly scroll to the position of invalid field.